### PR TITLE
Fix a crash introduced by the Xcode 14 generated `.xcresult`

### DIFF
--- a/xcresult/model.py
+++ b/xcresult/model.py
@@ -100,12 +100,15 @@ class DocumentLocation(XcresultObject):
         return self.url.split("#")[0].replace("file://", "")
 
     @property
-    def location(self) -> str:
+    def location(self) -> Optional[str]:
         """Get the raw location inside the document
 
-        :returns: The location inside the document
+        :returns: The location inside the document if set, None otherwise
         """
-        return self.url.split("#")[1]
+        components = self.url.split("#")
+        if len(components) > 1:
+            return components[1]
+        return None
 
     @property
     def location_details(self) -> Dict[str, List[str]]:


### PR DESCRIPTION
The `url` of a `documentLocationInCreatingWorkspace` of the `.xcresult` generated by Xcode 14 can be something like `file:///Users/runner/work/1/s/app-ios/WatchKitExtension/RootViewHostingController.storyboard`, which will result in `list index out of range` crash.

Here's the sample:
```json
"documentLocationInCreatingWorkspace" : {
  "_type" : {
    "_name" : "DocumentLocation"
  },
  "concreteTypeName" : {
    "_type" : {
      "_name" : "String"
    },
    "_value" : "DVTMemberDocumentLocation"
  },
  "url" : {
    "_type" : {
      "_name" : "String"
    },
    "_value" : "file:\/\/\/Users\/runner\/work\/1\/s\/app-ios\/WatchKitExtension\/RootViewHostingController.storyboard"
  }
}
```